### PR TITLE
Ability to specific device for playback in miniaudio

### DIFF
--- a/pyminiaudio/build_ffi_module.py
+++ b/pyminiaudio/build_ffi_module.py
@@ -310,7 +310,7 @@ typedef enum
     ma_backend_aaudio,
     ma_backend_opensl,
     ma_backend_webaudio,
-    ma_backend_null    
+    ma_backend_null
 } ma_backend;
 
     typedef int8_t   ma_int8;
@@ -324,8 +324,8 @@ typedef enum
     typedef uintptr_t ma_uintptr;
     typedef ma_uint8                   ma_bool8;
     typedef ma_uint32                  ma_bool32;
-    
-    
+
+
 typedef enum
 {
     ma_dither_mode_none = 0,
@@ -367,7 +367,7 @@ typedef enum
     ma_thread_priority_default  =  0
 } ma_thread_priority;
 
-    
+
 typedef enum
 {
     ma_device_type_playback = 1,
@@ -383,6 +383,7 @@ typedef enum
 
 
 typedef union ma_device_id {
+    wchar_t wasapi[64];
     ...;
 } ma_device_id;
 typedef struct ma_context {
@@ -421,9 +422,10 @@ typedef struct
     ma_uint32 maxChannels;
     ma_uint32 minSampleRate;
     ma_uint32 maxSampleRate;
-    
+
     ...;
 } ma_device_info;
+
 
 
 typedef struct
@@ -435,10 +437,22 @@ typedef struct
     ma_device_callback_proc dataCallback;
     ma_stop_proc stopCallback;
     void* pUserData;
-    
-    /* TODO: missing 'playback' nested struct */
-    /* TODO: missing 'capture' nested struct */
-    
+    struct
+    {
+        ma_device_id* pDeviceID;
+        ma_format format;
+        ma_uint32 channels;
+        ma_channel channelMap[MA_MAX_CHANNELS];
+        ma_share_mode shareMode;
+    } playback;
+    struct
+    {
+        ma_device_id* pDeviceID;
+        ma_format format;
+        ma_uint32 channels;
+        ma_channel channelMap[MA_MAX_CHANNELS];
+        ma_share_mode shareMode;
+    } capture;
     ...;
 } ma_device_config;
 
@@ -467,7 +481,7 @@ typedef struct ma_decoder
     ma_format  outputFormat;
     ma_uint32  outputChannels;
     ma_uint32  outputSampleRate;
-    
+
     ...;
 } ma_decoder;
 
@@ -506,14 +520,14 @@ typedef ma_bool32 (* ma_enum_devices_callback_proc)(ma_context* pContext, ma_dev
     ma_result ma_decoder_init_file_flac(const char* pFilePath, const ma_decoder_config* pConfig, ma_decoder* pDecoder);
     ma_result ma_decoder_init_file_vorbis(const char* pFilePath, const ma_decoder_config* pConfig, ma_decoder* pDecoder);
     ma_result ma_decoder_init_file_mp3(const char* pFilePath, const ma_decoder_config* pConfig, ma_decoder* pDecoder);
-    
+
     ma_result ma_decoder_uninit(ma_decoder* pDecoder);
     ma_uint64 ma_decoder_get_length_in_pcm_frames(ma_decoder* pDecoder);
     ma_uint64 ma_decoder_read_pcm_frames(ma_decoder* pDecoder, void* pFramesOut, ma_uint64 frameCount);
     ma_result ma_decoder_seek_to_pcm_frame(ma_decoder* pDecoder, ma_uint64 frameIndex);
     ma_result ma_decode_file(const char* pFilePath, ma_decoder_config* pConfig, ma_uint64* pFrameCountOut, void** ppDataOut);
     ma_result ma_decode_memory(const void* pData, size_t dataSize, ma_decoder_config* pConfig, ma_uint64* pFrameCountOut, void** ppDataOut);
-    
+
     /**** format conversion ****/
     /* TODO: add the streaming DSP conversion API */
     void ma_pcm_u8_to_s16(void* pOut, const void* pIn, ma_uint64 count, ma_dither_mode ditherMode);
@@ -549,10 +563,10 @@ typedef ma_bool32 (* ma_enum_devices_callback_proc)(ma_context* pContext, ma_dev
 
     void init_miniaudio(void);
     void ma_device_config_set_params(ma_device_config* config, ma_uint32 sample_rate, ma_uint32 buffer_size_msec, ma_uint32 buffer_size_frames,
-       ma_format format, ma_uint32 channels, ma_format capture_format, ma_uint32 capture_channels);
+       ma_format format, ma_uint32 channels, ma_format capture_format, ma_uint32 capture_channels, ma_device_id* playback_device_id, ma_device_id* capture_device_id);
 
     extern "Python" void internal_data_callback(ma_device* pDevice, void* pOutput, const void* pInput, ma_uint32 frameCount);
-    
+
 """)
 
 
@@ -580,14 +594,14 @@ ffibuilder.set_source("_miniaudio", """
     #endif
 
     #include "miniaudio/miniaudio.h"
-    
+
     /* low-level initialization */
     void init_miniaudio(void);
-    
+
     /* helper function to set some parameters in the ma_device_config struct which couldn't be parsed by cffi directly */
     void ma_device_config_set_params(ma_device_config* config, ma_uint32 sample_rate, ma_uint32 buffer_size_msec, ma_uint32 buffer_size_frames,
-       ma_format format, ma_uint32 channels, ma_format capture_format, ma_uint32 capture_channels);
-    
+       ma_format format, ma_uint32 channels, ma_format capture_format, ma_uint32 capture_channels, ma_device_id* playback_device_id, ma_device_id* capture_device_id);
+
 """,
                       sources=["miniaudio.c"],
                       include_dirs=[miniaudio_include_dir],

--- a/pyminiaudio/examples/demo4.py
+++ b/pyminiaudio/examples/demo4.py
@@ -1,0 +1,17 @@
+import os
+import miniaudio
+from miniaudio import ffi
+
+def samples_path(filename):
+    return os.path.join(os.path.abspath(os.path.dirname(__file__)), 'samples', filename)
+
+if __name__ == "__main__":
+    devices = miniaudio.Devices()
+    selected_device = devices.get_playbacks()[0]
+    print("Playing back through {}".format(selected_device.name))
+
+
+    stream = miniaudio.stream_file(samples_path("music.mp3"))
+    device = miniaudio.PlaybackDevice(device_id=selected_device.id)
+    device.start(stream)
+    input("Audio file playing in the background. Enter to stop playback: ")

--- a/pyminiaudio/examples/devices.py
+++ b/pyminiaudio/examples/devices.py
@@ -1,0 +1,23 @@
+import os
+import miniaudio
+import json
+
+if __name__ == "__main__":
+    devices = miniaudio.Devices()
+    print("Backend: {}".format(devices.backend))
+    print("\n")
+
+    out_devices = devices.get_playbacks()
+    print("Playback Devices")
+    for device in out_devices:
+        print("  {}".format(device.name))
+        print("    {}".format(device.info()))
+        print("\n")
+
+    in_devices = devices.get_captures()
+    print("Capture Devices")
+    for device in in_devices:
+        print("  {}".format(device.name))
+        print("    {}".format(device.info()))
+        print("\n")
+

--- a/pyminiaudio/miniaudio.c
+++ b/pyminiaudio/miniaudio.c
@@ -70,12 +70,8 @@ void ma_device_config_set_params(ma_device_config* config, ma_uint32 sample_rate
     config->playback.channels = channels;
     config->capture.format = capture_format;
     config->capture.channels = capture_channels;
-    // if (capture_device_id != NULL) {
-    //     config->capture.pDeviceID = capture_device_id;
-    // }
-    // if (playback_device_id != NULL) {
+    config->capture.pDeviceID = capture_device_id;
     config->playback.pDeviceID = playback_device_id;
-    // }
 }
 
 

--- a/pyminiaudio/miniaudio.c
+++ b/pyminiaudio/miniaudio.c
@@ -62,7 +62,7 @@ void init_miniaudio(void) {
 
 
 void ma_device_config_set_params(ma_device_config* config, ma_uint32 sample_rate, ma_uint32 buffer_size_msec,
-  ma_uint32 buffer_size_frames, ma_format format, ma_uint32 channels, ma_format capture_format, ma_uint32 capture_channels) {
+  ma_uint32 buffer_size_frames, ma_format format, ma_uint32 channels, ma_format capture_format, ma_uint32 capture_channels, ma_device_id* playback_device_id, ma_device_id* capture_device_id) {
     config->sampleRate = sample_rate;
     config->bufferSizeInFrames = buffer_size_frames;
     config->bufferSizeInMilliseconds = buffer_size_msec;
@@ -70,6 +70,12 @@ void ma_device_config_set_params(ma_device_config* config, ma_uint32 sample_rate
     config->playback.channels = channels;
     config->capture.format = capture_format;
     config->capture.channels = capture_channels;
+    // if (capture_device_id != NULL) {
+    //     config->capture.pDeviceID = capture_device_id;
+    // }
+    // if (playback_device_id != NULL) {
+    config->playback.pDeviceID = playback_device_id;
+    // }
 }
 
 

--- a/pyminiaudio/miniaudio.py
+++ b/pyminiaudio/miniaudio.py
@@ -649,6 +649,74 @@ def _get_filename_bytes(filename: str) -> bytes:
 
 
 # MiniAudio API follows
+PLAYBACK = 'playback'
+CAPTURE = 'capture'
+
+class Device:
+    name: str
+    device_type: str
+    id: ffi.CData
+
+    def __init__(self, device_type: str, ma_device_info: ffi.CData, context: ffi.CData):
+        self._device_info = ma_device_info
+        self.name = ffi.string(ma_device_info.name).decode()
+        self.id = ma_device_info.id
+        self.device_type = device_type
+        self._context = context
+
+    def info(self):
+        if self.device_type == PLAYBACK:
+            device_type = lib.ma_device_type_playback
+        elif self.device_type == CAPTURE:
+            device_type = lib.ma_device_type_capture
+        lib.ma_context_get_device_info(self._context, device_type, ffi.addressof(self.id), 0, ffi.addressof(self._device_info))
+        return {
+            # Should these be converted to snake case?
+            'minChannels': self._device_info.minChannels,
+            'maxChannels': self._device_info.maxChannels,
+            'minSampleRate': self._device_info.minSampleRate,
+            'maxSampleRate': self._device_info.maxSampleRate,
+            # TODO: Formats?
+        }
+
+class Devices:
+    def __init__(self):
+        self._context = ffi.new("ma_context*")
+        result = lib.ma_context_init(ffi.NULL, 0, ffi.NULL, self._context)
+        if result != lib.MA_SUCCESS:
+            raise MiniaudioError("cannot init context", result)
+
+        self.backend = ffi.string(lib.ma_get_backend_name(self._context[0].backend)).decode()
+
+        self.__cache = {}
+
+    def get_playbacks(self) -> List[Device]:
+        playback_infos = ffi.new("ma_device_info**")
+        playback_count = ffi.new("ma_uint32*")
+        result = lib.ma_context_get_devices(self._context, playback_infos, playback_count, ffi.NULL,  ffi.NULL)
+        if result != lib.MA_SUCCESS:
+            raise MiniaudioError("cannot get device infos", result)
+        devs = []
+        for i in range(playback_count[0]):
+            ma_device_info = playback_infos[0][i]
+            devs.append(Device(PLAYBACK, ma_device_info, self._context))
+        return devs
+
+    def get_captures(self) -> List[Device]:
+        capture_infos = ffi.new("ma_device_info**")
+        capture_count = ffi.new("ma_uint32*")
+        result = lib.ma_context_get_devices(self._context, ffi.NULL,  ffi.NULL, capture_infos, capture_count)
+        if result != lib.MA_SUCCESS:
+            raise MiniaudioError("cannot get device infos", result)
+        devs = []
+        for i in range(capture_count[0]):
+            ma_device_info = capture_infos[0][i]
+            devs.append(Device(CAPTURE, ma_device_info, self._context))
+        return devs
+
+    def __del__(self):
+        lib.ma_context_uninit(self._context)
+
 
 
 def get_devices() -> Tuple[List[str], List[str]]:
@@ -822,7 +890,7 @@ AudioProducerType = Generator[Union[bytes, array.array], int, None]
 class PlaybackDevice:
     """An audio device provided by miniaudio, for audio playback."""
     def __init__(self, ma_output_format: int = ma_format_s16, nchannels: int = 2,
-                 sample_rate: int = 44100, buffersize_msec: int = 200):
+                 sample_rate: int = 44100, buffersize_msec: int = 200, device_id: ffi.CData = ffi.NULL):
         self.format = ma_output_format
         self.sample_width, self.samples_array_proto = _decode_ma_format(ma_output_format)
         self.nchannels = nchannels
@@ -833,7 +901,7 @@ class PlaybackDevice:
         self.userdata_ptr = ffi.new("char[]", struct.pack('q', id(self)))
         self._devconfig = lib.ma_device_config_init(lib.ma_device_type_playback)
         lib.ma_device_config_set_params(ffi.addressof(self._devconfig), self.sample_rate, self.buffersize_msec,
-                                        0, self.format, self.nchannels, 0, 0)
+                                        0, self.format, self.nchannels, 0, 0, ffi.addressof(device_id), ffi.NULL)
         self._devconfig.pUserData = self.userdata_ptr
         self._devconfig.dataCallback = lib.internal_data_callback
         self.audio_producer = None   # type: Optional[AudioProducerType]

--- a/pyminiaudio/miniaudio.py
+++ b/pyminiaudio/miniaudio.py
@@ -890,7 +890,7 @@ AudioProducerType = Generator[Union[bytes, array.array], int, None]
 class PlaybackDevice:
     """An audio device provided by miniaudio, for audio playback."""
     def __init__(self, ma_output_format: int = ma_format_s16, nchannels: int = 2,
-                 sample_rate: int = 44100, buffersize_msec: int = 200, device_id: ffi.CData = ffi.NULL):
+                 sample_rate: int = 44100, buffersize_msec: int = 200, device_id: Union[ffi.CData, None] = None):
         self.format = ma_output_format
         self.sample_width, self.samples_array_proto = _decode_ma_format(ma_output_format)
         self.nchannels = nchannels
@@ -900,8 +900,12 @@ class PlaybackDevice:
         _callback_data[id(self)] = self
         self.userdata_ptr = ffi.new("char[]", struct.pack('q', id(self)))
         self._devconfig = lib.ma_device_config_init(lib.ma_device_type_playback)
+        if device_id:
+            _device_id = ffi.addressof(device_id)
+        else:
+            _device_id = ffi.NULL
         lib.ma_device_config_set_params(ffi.addressof(self._devconfig), self.sample_rate, self.buffersize_msec,
-                                        0, self.format, self.nchannels, 0, 0, ffi.addressof(device_id), ffi.NULL)
+                                        0, self.format, self.nchannels, 0, 0, _device_id, ffi.NULL)
         self._devconfig.pUserData = self.userdata_ptr
         self._devconfig.dataCallback = lib.internal_data_callback
         self.audio_producer = None   # type: Optional[AudioProducerType]


### PR DESCRIPTION
This is my first-pass adding in the ability to query for devices, and specific a `device_id` in the `PlaybackDevice` to control where playback occurs. 

```python
devices = miniaudio.Devices()
out_devices = devices.get_playbacks()

selected = out_devices[4]
print(device.name)
"Microphone (Yeti Stereo Microphone)"
print(device.info())
{'minChannels': 2, 'maxChannels': 2, 'minSampleRate': 48000, 'maxSampleRate': 48000}

in_devices = devices.get_captures()
# etc...
```

Opening this PR early to get any thoughts/feedback (especially around the API design).